### PR TITLE
Fixed a div/0 error that occured with a low-coverage sample. 

### DIFF
--- a/README.genomeAnalysisPancanSlim.txt
+++ b/README.genomeAnalysisPancanSlim.txt
@@ -10,7 +10,7 @@ Switch                      Default Description
 runCoveragePlotsOnly        false
 
 Value                       Description
-overrideFastqFiles          A list of
+overrideFastqFiles
 overrideSamples
 overrideBamFiles
 

--- a/resources/analysisTools/qcPipeline/bashLib.sh
+++ b/resources/analysisTools/qcPipeline/bashLib.sh
@@ -142,6 +142,18 @@ isDebugSet() {
     normalizeBoolean "${debug:-false}"
 }
 
+# Grep returns 1 if no match is found. Ensure that empty files are handled gracefully without exit due to `set -e`.
+grepIgnoreEmpty() {
+    (set +e    # The parentheses keep the `set -e` in the local subshell.
+    grep "$@"
+    if [[ $? -gt 1 ]]; then
+        return $?
+    else
+        return 0
+    fi)
+}
+
+
 
 #####################################################################
 ## Handling processes and tempfiles (original code from BamToFastqPlugin)

--- a/resources/analysisTools/qcPipeline/bwaErrorChecking.sh
+++ b/resources/analysisTools/qcPipeline/bwaErrorChecking.sh
@@ -11,55 +11,56 @@
 useMBufferStreaming="${useMBufferStreaming-false}"
 
 # Test for success before renaming!
-success=$(grep " fault" "$FILENAME_BWA_LOG")
-[[ ! -z "$success" ]] && throw 31 "found segfault '$success' in bwa logfile!"
+failure=$(grepIgnoreEmpty " fault" "$FILENAME_BWA_LOG")
+[[ -n "$failure" ]] && throw 31 "found segfault '$failure' in bwa logfile!"
 
 # if one of the read-files is terminated early (e.g. because of pipe error or error in file)
-success=$(grep "file has fewer sequences." ${FILENAME_BWA_LOG} || true)
-[[ ! -z "$success" ]] && throw 41 "found segfault '$success' in bwa logfile!"
+failure=$(grepIgnoreEmpty "file has fewer sequences." ${FILENAME_BWA_LOG} || true)
+[[ -n "$failure" ]] && throw 41 "found segfault '$failure' in bwa logfile!"
 
 # Barbara Aug 10 2015: I can't remember what bwa aln and sampe reported as "error".
 # bluebee bwa has "error_count" in bwa-0.7.8-r2.05; and new in bwa-0.7.8-r2.06: "WARNING:top_bs_ke_be_hw: dummy be execution, only setting error."
 # these are not errors that would lead to fail, in contrast to "ERROR: Bus error" 
-success=$(grep -i "error" "$FILENAME_BWA_LOG" | grep -v "error_count" | grep -v "dummy be execution")
-[[ ! -z "$success" ]] && throw 36 "found error '$success' in bwa logfile!"
+failure=$(grepIgnoreEmpty -i "error" "$FILENAME_BWA_LOG" | grepIgnoreEmpty -v "error_count" | grepIgnoreEmpty -v "dummy be execution")
+[[ -n "$failure" ]] && throw 36 "found error '$failure' in bwa logfile!"
 
-success=$(grep "Abort. Sorry." "$FILENAME_BWA_LOG")
-[[ ! -z "$success" ]] && throw 37 "found error '$success' in bwa logfile!"
+failure=$(grepIgnoreEmpty "Abort. Sorry." "$FILENAME_BWA_LOG")
+[[ -n "$failure" ]] && throw 37 "found error '$failure' in bwa logfile!"
 
 # An assumption of the workflow is violated.
-success=$(grep "file has fewer sequences." "$FILENAME_BWA_LOG")
-[[ ! -z "$success" ]] && throw 41 "found error '$success' in bwa logfile!"
+failure=$(grepIgnoreEmpty "file has fewer sequences." "$FILENAME_BWA_LOG")
+[[ -n "$failure" ]] && throw 41 "found error '$failure' in bwa logfile!"
 
 # samtools sort may complain about truncated temp files and for each line outputs
 # the error message. This happens when the same files are written at the same time,
 # see http://sourceforge.net/p/samtools/mailman/samtools-help/thread/BAA90EF6FE3B4D45A7B2F6E0EC5A8366DA3AB5@USTLMLLYC102.rf.lilly.com/
 # This happens when the scheduler puts the same job on 2 nodes bc. the prefix for samtools-0.1.19 -o $prefix is constructed using the job ID
 echo "testing $FILENAME_SORT_LOG"
-if [ ! -z $FILENAME_SORT_LOG ] && [ -f $FILENAME_SORT_LOG ]
-then
-	success=$(grep "is truncated. Continue anyway." "$FILENAME_SORT_LOG")
-	[[ ! -z "$success" ]] && throw 38 "found error '$success' in samtools sorting logfile!"
+if [[ -n "$FILENAME_SORT_LOG" && -f $FILENAME_SORT_LOG ]]; then
+	failure=$(grepIgnoreEmpty "is truncated. Continue anyway." "$FILENAME_SORT_LOG")
+	if [[ -n "$failure" ]]; then
+	    throw 38 "found error '$failure' in samtools sorting logfile!"
+	fi
 else
 	echo "there is no samtools sort log file"
 fi
 
-if [[ $(cat "$FILENAME_BWA_EC") != "0" ]]; then
-    throw 32 "There was a non-zero exit code in bwa pipe (w/ pipefail): $(cat '$FILENAME_BWA_EC'); exiting..."
+if [[ $(cat "$FILENAME_BWA_EC" | cut -f 1 -d ' ') != "0" ]]; then
+    throw 32 "There was a non-zero exit code in bwa pipe (w/ pipefail): $(cat \"$FILENAME_BWA_EC\"); exiting..."
 fi
 
 # disable file size checks if the interprocess streaming is active
-if [[ $useMBufferStreaming != true ]]
-then
+if [[ $useMBufferStreaming != true ]]; then
 
-    if [[ "2048" -gt `stat -c %s "$TMP_FILE"` ]]
-    then
+    if [[ "2048" -gt `stat -c %s "$TMP_FILE"` ]]; then
         errorString="Output file is too small!"
         throw 33 "$errorString"
     fi
 
     # TODO Check that?
-    [[ "$?" != "0"  ]] && throw 32 "$errorString"
+    if [[ "$?" != "0"  ]]; then
+        throw 32 "$errorString"
+    fi
 fi
 
-echo all OK
+echo "all OK"

--- a/resources/analysisTools/qcPipeline/flags_isizes_PEaberrations.pl
+++ b/resources/analysisTools/qcPipeline/flags_isizes_PEaberrations.pl
@@ -75,7 +75,7 @@ while (!eof($chromFh)) {
 	if ($line =~ /^#/) {
 		next;
 	}
-	chomp;
+	chomp $line;
 	@help = split ("\t", $line);
 	$chroms{$help[0]} = 1;
 	$chromarray[$chrnum] = $help[0];
@@ -183,20 +183,21 @@ if ($ctr == 0) {
 # in case we have single end reads, there will be no counted ones for isizes ($ctr < 1)
 # and PE aberrations ($aberrant < 1) => fill the files with placeholder "NA"
 
+my $percentage = "NA";
 if ($aberrant < 1) {
 	print STDERR "no aberrant paired reads found, single end reads?\n";
-	print $percImproperPairedFh "NA\n";
 } else {
-	if ($ctr == 0) {
-		$average = "NA";
-	} else {
+	$average = "NA";
+	if ($ctr > 0) {
 		$average = $sum / $ctr;
 	}
 	print STDERR "insert sizes: $pp_strange proper pairs with insert size > $maxisize; $ctr values in range. minimum: $min; maximum: $max; average: $average\n";
 	print STDERR "from $all reads, $aberrant are paired end aberrations\n";
-	my $percentage = sprintf ("%2.2f\n", ($aberrant/$both*100));
-	print $percImproperPairedFh $percentage;
+	if ($both > 0) {
+		$percentage = sprintf("%2.2f", ($aberrant / $both * 100));
+	}
 }
+print $percImproperPairedFh $percentage . "\n";
 close $percImproperPairedFh;
 
 # print out matrix
@@ -233,7 +234,7 @@ close $matrixFh;
 
 if ($ctr < 1) {
 	print $isizesbinFh "NA\n";
-	print $isizesbinFh "NA\nNA\nNA\n";
+	print $isizesFh "NA\nNA\nNA\n";
 } else {
 	my $isize_mindiff = $ctr/50000;	#10000;	# for 30x genome, but less reads means less difference!
 	print STDERR "for insert size slope detection, set min difference to $isize_mindiff\n";
@@ -280,7 +281,7 @@ if ($ctr < 1) {
 			$docollect = 0;
 		}
 		# squared deviations from the average
-		$devsqsum += $howmany * (($i - $average)**2);
+		$devsqsum += $howmany * (($i - $average) ** 2);
 	}
 
 	my $stddev = "NA";

--- a/resources/analysisTools/qcPipeline/flags_isizes_PEaberrations.pl
+++ b/resources/analysisTools/qcPipeline/flags_isizes_PEaberrations.pl
@@ -29,8 +29,7 @@ my $chromfile = $opts{c};
 my $flagsout = $opts{f};
 my $minmapq = $opts{n};
 
-if (defined $opts{h} || ! defined $samfile || ! defined $isizebinout  || ! defined $isizeoutfile || ! defined $matrixout || ! defined $chromfile || ! defined $flagsout)
-{
+if (defined $opts{h} || ! defined $samfile || ! defined $isizebinout  || ! defined $isizeoutfile || ! defined $matrixout || ! defined $chromfile || ! defined $flagsout) {
 	die "USAGE: $0 [options]
 	-a FILE	file to write the matrix with different chromosomes out to (_DiffChroms.txt)
 	-b FILE	file to write the insert size bins out to (_insertsizes.txt)
@@ -44,26 +43,23 @@ if (defined $opts{h} || ! defined $samfile || ! defined $isizebinout  || ! defin
 	-h help\n";
 }
 
-open (IN, $samfile) or die "Cannot open $samfile: $!\n";
-open (CF, $chromfile) or die "Cannot open $chromfile: $!\n";
-open (IB, ">$isizebinout") or die "could not open $isizebinout for writing: $!\n";
-open (IS, ">$isizeoutfile")  or die "could not open $isizeoutfile for writing: $!\n";
-open (MA, ">$matrixout") or die "could not open $matrixout for writing: $!\n";
-open (FL, ">$flagsout") or die "could not open $flagsout for writing: $!\n";
-open (PE, ">$peaberrstat") or die "could not open $peaberrstat for writing: $!\n";
+open (my $samFh, $samfile) or die "Cannot open $samfile: $!\n";
+open (my $chromFh, $chromfile) or die "Cannot open $chromfile: $!\n";
+open (my $isizesbinFh, ">$isizebinout") or die "could not open $isizebinout for writing: $!\n";
+open (my $isizesFh, ">$isizeoutfile")  or die "could not open $isizeoutfile for writing: $!\n";
+open (my $matrixFh, ">$matrixout") or die "could not open $matrixout for writing: $!\n";
+open (my $flagsFh, ">$flagsout") or die "could not open $flagsout for writing: $!\n";
+open (my $percImproperPairedFh, ">$peaberrstat") or die "could not open $peaberrstat for writing: $!\n";
 
-if ($maxisize !~ /^\d+$/)
-{
+if ($maxisize !~ /^\d+$/) {
 	print STDERR "maximal insert size $maxisize is not a number, setting to default 1000\n";
 	$maxisize = 1000;
 }
-if ($maxisize < 1000)
-{
+if ($maxisize < 1000) {
 	print STDERR "maximal insert size $maxisize is unreasonably small, setting to default 1000\n";
 	$maxisize = 1000;
 }
-if ($minmapq !~ /^\d+$/)
-{
+if ($minmapq !~ /^\d+$/) {
 	print STDERR "minimal mapping quality $minmapq is not a number, setting to default 1\n";
 	$minmapq = 1;
 }
@@ -73,19 +69,19 @@ my @help = ();
 my %chroms = ();	# to look up later if the chromosome is wanted
 my @chromarray = ();	# for the output in matrix form
 my $chrnum = 0;
-while (<CF>)
-{
-	if ($_ =~ /^#/)
-	{
+while (!eof($chromFh)) {
+	my $line = readline($chromFh)
+		|| die "Could not read from chromosome file '$chromfile': $!";
+	if ($line =~ /^#/) {
 		next;
 	}
 	chomp;
-	@help = split ("\t", $_);
+	@help = split ("\t", $line);
 	$chroms{$help[0]} = 1;
 	$chromarray[$chrnum] = $help[0];
 	$chrnum++;
 }
-close CF;
+close $chromFh;
 print STDERR "$chrnum chromosomes to keep: @chromarray\n";
 
 # extended flagstats
@@ -114,62 +110,57 @@ my $sum = 0;	# sum of insert sizes
 my $pp_strange = 0;
 my $average = 0;
 
-while (<IN>)
-{
-	if ($_ =~ /^\@/)	# there might be a SAM header
-	{next;}
+while (!eof($samFh)) {
+	my $line = readline($samFh)
+		|| die "Couldn't read SAM file '$samFh': $!";
+
+	if ($line =~ /^\@/)	{
+		# there might be a SAM header
+		next;
+	}
 	$all++;
-	@help = split ("\t", $_);
+	@help = split ("\t", $line);
 	$flag = $help[1];
 	# not unmapped, no duplicate and no secondary/supplementary alignment, and mapqual >= X
 	if (!($flag & 4) && !($flag & 1024) && !($flag & 256) && !($flag & 2048))
 	{
 		$uniq++;
-		if ($help[4] >= $minmapq)
-		{
+		if ($help[4] >= $minmapq) {
 			# of these, with mapqual >= X
 			$minmapuniq++;
-		}
-		else
-		{
+		} else {
 			next;
 		}
 		# is the read itself on a wanted chromosome?
-		if (defined $chroms{$help[2]})
-		{
+		if (defined $chroms{$help[2]}) {
 			$onchr++;
 			# and the mate on a wanted chromosome
-			if (defined $chroms{$help[6]} || $help[6] eq "=")	# same chrom is usually indicated by "=" instead of repeating the name
-			{
+			if (defined $chroms{$help[6]} || $help[6] eq "=") {
+				# same chrom is usually indicated by "=" instead of repeating the name
 				$both++;
 				# paired end aberration:  mate also has to be mapped, on a different chrom
-				if (!($flag & 8) && $help[6] ne "=" && ($help[2] ne $help[6]))
-				# keep matrix symmetrical to see whether there is a bias, e.g. more 1->10 than 10->1
-				{
+				if (!($flag & 8) && $help[6] ne "=" && ($help[2] ne $help[6])) {
+					# keep matrix symmetrical to see whether there is a bias, e.g. more 1->10 than 10->1
 					$aberrant++;
 					# only use read1 info, since read2 might have mapq 0, and the info of having bias w.r.t. which read
 					# is more interesting
-					if ($flag & 64)
-					{
+					if ($flag & 64) {
 						$chrompairs{$help[2]}{$help[6]}++;
 					}
 				}
 				# for insert sizes, take first read of a proper pair (-f 67 = 64 (first in pair) + 2 (proper pair) + 1 (paired));
 				# discarding duplicates (-F 1024) is already done further up
-				if ($flag & 64 && $flag & 2 && $flag & 1)
-				{
+				if ($flag & 64 && $flag & 2 && $flag & 1) {
 					$entry = abs($help[8]);	# insert size
-					if ($entry < $min)
-					{
+					if ($entry < $min) {
 						$min = $entry;
 					}
-					if ($entry > $maxisize)	# bwa can give "proper pair" to ones with insert size over 200 million bp, makes no sense at all!
-					{
+					if ($entry > $maxisize) {
+						# bwa can give "proper pair" to ones with insert size over 200 million bp, makes no sense at all!
 						$pp_strange++;
 						next;
 					}
-					if ($entry > $max)
-					{
+					if ($entry > $max) {
 						$max = $entry;
 					}
 					$isizes[$entry]++;
@@ -180,62 +171,58 @@ while (<IN>)
 		}
 	}
 }
-close IN;
+close $samFh;
 # extended flagstats
-print FL "total alignments\t$all\nnon-duplicate, non-secondary, non-supplementary reads\t$uniq\nsuch with mapping quality >=$minmapq\t$minmapuniq\nsuch on regarded chromosomes\t$onchr\nsuch with both reads on regarded chromosomes\t$both\nsuch mapping on different chromosomes\t$aberrant\nproper pairs read 1\t$ctr\n";
-close FL;
+print $flagsFh "total alignments\t$all\nnon-duplicate, non-secondary, non-supplementary reads\t$uniq\nsuch with mapping quality >=$minmapq\t$minmapuniq\nsuch on regarded chromosomes\t$onchr\nsuch with both reads on regarded chromosomes\t$both\nsuch mapping on different chromosomes\t$aberrant\nproper pairs read 1\t$ctr\n";
+close $flagsFh;
 
+if ($ctr == 0) {
+	print STDERR "No properly paired reads found! Is this single end data? Is the input file truncated?\n";
+}
 
 # in case we have single end reads, there will be no counted ones for isizes ($ctr < 1)
 # and PE aberrations ($aberrant < 1) => fill the files with placeholder "NA"
 
-if ($aberrant < 1)
-{
+if ($aberrant < 1) {
 	print STDERR "no aberrant paired reads found, single end reads?\n";
-	print PE "NA\n";
-}
-else
-{
-	$average = $sum/$ctr;
+	print $percImproperPairedFh "NA\n";
+} else {
+	if ($ctr == 0) {
+		$average = "NA";
+	} else {
+		$average = $sum / $ctr;
+	}
 	print STDERR "insert sizes: $pp_strange proper pairs with insert size > $maxisize; $ctr values in range. minimum: $min; maximum: $max; average: $average\n";
 	print STDERR "from $all reads, $aberrant are paired end aberrations\n";
 	my $percentage = sprintf ("%2.2f\n", ($aberrant/$both*100));
-	print PE $percentage;
+	print $percImproperPairedFh $percentage;
 }
-close PE;
+close $percImproperPairedFh;
 
 # print out matrix
-if ($aberrant < 1)
-{
-	print MA "NA\n";
-}
-else
-{
+if ($aberrant < 1) {
+	print $matrixFh "NA\n";
+} else {
 	my $chromstring = join ("\t", @chromarray);
 	# $chrnum is the number of chromosomes wanted = length of the @chromarray
-	print MA "\t$chromstring\n";
+	print $matrixFh "\t$chromstring\n";
 	my $chrom = "";
 	my $chrmate = "";
-	for (my $c1 = 0; $c1 < $chrnum; $c1++)
-	{
+	for (my $c1 = 0; $c1 < $chrnum; $c1++) {
 		$chrom = $chromarray[$c1];	# the actual chromosome name of the read
-		print MA "$chrom";
-		for (my $c2 = 0; $c2 < $chrnum; $c2++)
-		{
+		print $matrixFh "$chrom";
+		for (my $c2 = 0; $c2 < $chrnum; $c2++) {
 			$chrmate = $chromarray[$c2];	# ... of the mate
-			if (exists $chrompairs{$chrom} && exists $chrompairs{$chrom}{$chrmate})
-			{
-				print MA "\t", $chrompairs{$chrom}{$chrmate};
-			}
-			else
-			{
-				print MA "\t0";
+			if (exists $chrompairs{$chrom} && exists $chrompairs{$chrom}{$chrmate}) {
+				print $matrixFh "\t", $chrompairs{$chrom}{$chrmate};
+			} else {
+				print $matrixFh "\t0";
 			}
 		}
-		print MA "\n";
+		print $matrixFh "\n";
 	}
 }
-close MA;
+close $matrixFh;
 
 # insert size statistics
 # The median is in a sorted list the value in the middle. The list is actually sorted but contains the same values several times.
@@ -244,14 +231,10 @@ close MA;
 # here for simplicity, just take the value when read number is > 1/2 of all
 # Also get the standard deviation by the sqrt of the deviations from the average by going through the list efficiently
 
-if ($ctr < 1)
-{
-	print STDERR "no properly paired reads found, single end reads?\n";
-	print IB "NA\n";
-	print IS "NA\nNA\nNA\n";
-}
-else
-{
+if ($ctr < 1) {
+	print $isizesbinFh "NA\n";
+	print $isizesbinFh "NA\nNA\nNA\n";
+} else {
 	my $isize_mindiff = $ctr/50000;	#10000;	# for 30x genome, but less reads means less difference!
 	print STDERR "for insert size slope detection, set min difference to $isize_mindiff\n";
 	my $median = 0;
@@ -270,13 +253,11 @@ else
 
 	# print for plotting with R:
 	# insertsize_bin\tnumber_reads
-	for (my $i = $min; $i <= $max; $i++)
-	{
+	for (my $i = $min; $i <= $max; $i++) {
 		$howmany = $isizes[$i] || 0;
-		print IB "$i\t$howmany\n";
+		print $isizesbinFh "$i\t$howmany\n";
 		# find highest peak
-		if ($howmany > 1000 && $howmany > $modnr)
-		{
+		if ($howmany > 1000 && $howmany > $modnr) {
 			$modnr = $howmany;
 			$mode1 = $i;
 		}
@@ -284,8 +265,7 @@ else
 		# this is not optimal because after a small dip, there could be the real first peak
 		# if ($howmany > 1000 && $howmany < $oldnr && $newmode > 0)
 		# try to avoid detecting noise: the slope after the peak must be really steep
-		if ($howmany > 1000 && $howmany < $oldnr && $newmode > 0 && (abs($howmany - $isizes[$i+1]) > $isize_mindiff))
-		{
+		if ($howmany > 1000 && $howmany < $oldnr && $newmode > 0 && (abs($howmany - $isizes[$i+1]) > $isize_mindiff)) {
 			$mode = $mode1;
 			$mode1 = 0;
 			$modnr = 0;
@@ -293,8 +273,8 @@ else
 		}
 		$ctr2+=$howmany;
 		$oldnr = $howmany;
-		if ($ctr2 >= $middle && $docollect > 0)	# we have hit the middle, fix the median!
-		{
+		if ($ctr2 >= $middle && $docollect > 0)	{
+			# we have hit the middle, fix the median!
 			$median = $i;
 			print STDERR "hit middle ($middle) at $ctr2 entries: median is $i\n";
 			$docollect = 0;
@@ -307,7 +287,7 @@ else
 	my $sdrd = "NA";
 	my $sdperc = "NA";
 	my $rounded = "NA";
-	if ($ctr - 1 != 0) {
+	if ($ctr > 1) {
 		$stddev = sqrt($devsqsum/($ctr-1));
 		$sdrd = int($stddev+0.5);
 		$sdperc = $stddev/$median*100;
@@ -315,29 +295,23 @@ else
 	}
 	print STDERR "stddev: $stddev; rounded: $sdrd\n";
 	print STDERR "median: $median; SDpercent: $sdperc; rounded: $rounded\n";
-	print IS "$median\n$rounded\n$sdrd\n";
+	print $isizesFh "$median\n$rounded\n$sdrd\n";
 
 	# mode(s) often there is an intitial "peak" at 0 that does not count
-	if ($mode1 > 0 && $mode > 0)
-	{
+	if ($mode1 > 0 && $mode > 0) {
 		print STDERR "2 peaks: $mode and $mode1";
 		# if the difference between the 2 peaks is small, it was just a random fluctuation,
 		# i.e. a small dip before the real peak
-		if (($mode1 - $mode) > 20)
-		{
+		if (($mode1 - $mode) > 20) {
 			print STDERR " - caution, bimodal distribution, might be adapter dimers!\n";
-			print IS "INSERT SIZE DISTRIBUTION POSSIBLY BIMODAL: (first) 2 peaks at $mode and $mode1\n";
-		}
-		else
-		{
+			print $isizesFh "INSERT SIZE DISTRIBUTION POSSIBLY BIMODAL: (first) 2 peaks at $mode and $mode1\n";
+		} else {
 			print STDERR " - small difference does not hint at critical binomial distribution.\n";
 		}
-	}
-	else
-	{
+	} else {
 		print STDERR "1 peak: $mode\n";
 	}
 }
-close IS;
-close IB;
+close $isizesFh;
+close $isizesbinFh;
 exit;


### PR DESCRIPTION
* ... in `flags_isizes_PEaberrations.pl`
* Turned from <> idiom to eof()+getline() idiom for improved runtime-stability and error reporting.
* Some code-layout fixes.
* Use $ variables rather than old FH names and substituted context-dependent $_ variable occurrences by something more informative.
* Some fixes in the bwaErrorCheck.sh script

Everything tested on one sample that failed due to lack of quality reads.
