### PR TITLE
mbuffer as module

### DIFF
--- a/resources/analysisTools/qcPipeline/environments/tbi-lsf-cluster.sh
+++ b/resources/analysisTools/qcPipeline/environments/tbi-lsf-cluster.sh
@@ -94,6 +94,9 @@ export PICARD_BINARY=picard.sh
 moduleLoad vcftools
 export VCFTOOLS_SORT_BINARY=vcf-sort
 
+moduleLoad mbuffer
+export MBUFFER_BINARY=mbuffer
+
 # There are different sambamba versions used for different tasks. The reason has something to do with performance and differences in the versions.
 # We define functions here that take the same parameters as the original sambamba, but apply them to the appropriate version by first loading
 # the correct version and after the call unloading the version. The _BINARY variables are set to the functions.
@@ -150,5 +153,4 @@ else
 fi
 
 # Unversioned binaries.
-export MBUFFER_BINARY=mbuffer
 export CHECKSUM_BINARY=md5sum

--- a/resources/configurationFiles/analysisQC.xml
+++ b/resources/configurationFiles/analysisQC.xml
@@ -21,6 +21,8 @@
                 description="Only used for 'view' and 'sort'."/>
         <cvalue name="SAMBAMBA_FLAGSTATS_VERSION" value="0.4.6" type="string"
                 description="Version 0.4.6 of sambamba produces the old samtools 0.1.19 compatible counts."/>
+        <cvalue name="MBUFFER_VERSION" value="20160613" type="string"
+                description="Newer mbuffer versions (e.g. 2019) additionally require to set the -s parameter to avoid sudden mbuffer termination for small buffer-sizes (e.g. 100M). This is not implemented in this workflow version."/>
         <cvalue name="SAMBAMBA_MARKDUP_VERSION" value="0.5.9" type="string"
                 description="Only used for duplication marking."/>
         <cvalue name="PICARD_VERSION" value="1.125" type="string"/>


### PR DESCRIPTION
An interface change in newer (at least 20181119) version of mbuffer causes small mbuffers to crash without exit code (I'd say a bug). Fixed version to version via module load 20160613.