### PR TITLE
Added MBUFFER_VERSION and module loading to correct 2018/2016 mbuffer…

### DIFF
--- a/resources/analysisTools/qcPipeline/environments/tbi-lsf-cluster.sh
+++ b/resources/analysisTools/qcPipeline/environments/tbi-lsf-cluster.sh
@@ -91,6 +91,9 @@ export PICARD_BINARY=picard.sh
 moduleLoad vcftools
 export VCFTOOLS_SORT_BINARY=vcf-sort
 
+moduleLoad mbuffer
+export MBUFFER_BINARY=mbuffer
+
 # There are different sambamba versions used for different tasks. The reason has something to do with performance and differences in the versions.
 # We define functions here that take the same parameters as the original sambamba, but apply them to the appropriate version by first loading
 # the correct version and after the call unloading the version. The _BINARY variables are set to the functions.
@@ -147,5 +150,4 @@ else
 fi
 
 # Unversioned binaries.
-export MBUFFER_BINARY=mbuffer
 export CHECKSUM_BINARY=md5sum

--- a/resources/configurationFiles/analysisQC.xml
+++ b/resources/configurationFiles/analysisQC.xml
@@ -17,6 +17,8 @@
         <cvalue name='BEDTOOLS_VERSION' value='2.16.2' type='string'/>
         <cvalue name="VCFTOOLS_VERSION" value="0.1.10" type="string"/>
         <cvalue name="SAMTOOLS_VERSION" value="0.1.19" type="string"/>
+        <cvalue name="MBUFFER_VERSION" value="20160613" type="string"
+                description="Newer mbuffer versions (e.g. 2019) additionally require to set the -s parameter to avoid sudden mbuffer termination for small buffer-sizes (e.g. 100M). This is not implemented in this workflow version."/>
         <cvalue name="SAMBAMBA_VERSION" value="0.4.6" type="string"
                 description="Only used for 'view' and 'sort'."/>
         <cvalue name="SAMBAMBA_FLAGSTATS_VERSION" value="0.4.6" type="string"


### PR DESCRIPTION
… version differences by fixing version to 2016 version.

These are the same changes as in the pull request 56:

https://github.com/DKFZ-ODCF/AlignmentAndQCWorkflows/pull/56/files