### PR TITLE
Draft: BWA MEM 2 support

### DIFF
--- a/resources/configurationFiles/analysisQC.xml
+++ b/resources/configurationFiles/analysisQC.xml
@@ -30,7 +30,11 @@
         <cvalue name="BIOBAMBAM_VERSION" value="0.0.148" type="string"/>
         <cvalue name="JAVA_VERSION" value="1.8.0_131" type="string"/>
         <cvalue name="BWA_VERSION" value="0.7.8" type="string"
-                description="Use e.g. 0.7.8-r2.05 for a specific revision of bb-bwa."/>
+                description="Use e.g. 0.7.8-r2.05 for a specific revision of bb-bwa. Node that bwa-mem2 uses much more memory."/>
+        <cvalue name="BWA_MODULE" value="" type="string"
+                description="Empty string will result in automatic inference of the module name. If the first number (major version) is '2' then BWA_MODULE is automatically set to 'bwa-mem2', otherwise 'bwa'. See tbi-lsf-cluster.sh. You can also explicitly set the version."/>
+        <cvalue name="BWA_MEM_OPTIONS" value='" -T 0 "' type="string"
+                description="The original CO configuration is ' -T 0 '. Note that  the value must be quoted."/>
         <cvalue name="FASTQC_VERSION" value="0.11.3" type="string"/>
 
         <cvalue name="workflowEnvironmentScript" value="workflowEnvironment_tbiLsf" type="string"/>


### PR DESCRIPTION
* For #66 
* Support is only via tbi-lsf-cluster.sh.

# TODO

* Unclear how to change the resource requirements. BWA MEM 2 needs more memory and can use more cores (with advantage for the processing time), but that could mean that we have to change the resource sets. Many people actually use the "xl" resource set size for historical reasons. There is no "xxl" set, though.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

New Features:
- Enhanced the BWA module in the analysis tools to automatically infer the module name and binary filename from the BWA version number, improving workflow efficiency.
- Added a new feature to the "bisulfiteCoreAnalysis" workflow that checks the BWA version and adjusts it to include the "-bisulfite" suffix if necessary, ensuring accurate analysis.
- Updated the "qcAnalysis" and "exomeAnalysis" workflows to set the BWA binary based on the use of accelerated hardware, enhancing performance.

Refactor:
- Streamlined the logic for loading the BWA module and setting the BWA binary, making the code more efficient and easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->